### PR TITLE
Ability Indicator now Dissappears, Can close with 'u'

### DIFF
--- a/src/components/controls/index.tsx
+++ b/src/components/controls/index.tsx
@@ -152,7 +152,7 @@ const mapDispatchToProps = (dispatch: RootDispatch): DispatchProps => ({
     movePlayer: (direction: Direction): void => dispatch(move(direction)),
     toggleInventory: (): void => dispatch(toggleInventory()),
     toggleSettings: (): void => dispatch(toggleSettings()),
-    openAbilityScoreDialog: (): void => dispatch(abilityScoreDialog(false)),
+    openAbilityScoreDialog: (): void => dispatch(abilityScoreDialog(true)),
     playerAttack: (): void => dispatch(playerAttack()),
     toggleJournal: (): void => dispatch(toggleJournal()),
     toggleSpellbookDialog: (): void => dispatch(toggleSpellbookDialog()),

--- a/src/components/dialog-manager/actions/ability-score-dialog.ts
+++ b/src/components/dialog-manager/actions/ability-score-dialog.ts
@@ -1,19 +1,12 @@
 import { RootThunk } from "../../../store";
 import { pause, setLevelUpAbilities } from "../../../store/dialog/actions";
 
-import { LEVEL_UP_ABILITY_POINTS } from "../../../constants";
-
-const abilityScoreDialog = (fromLevelUp: boolean): RootThunk => async (dispatch, getState): Promise<void> => {
-    // fromLevelUp tells us if we were called from the level up dialog or not
+const abilityScoreDialog = (openedByPlayer = false): RootThunk => async (dispatch, getState): Promise<void> => {
     const { abilities } = getState().stats;
-
-    if (fromLevelUp) {
-        abilities.points += LEVEL_UP_ABILITY_POINTS;
-    }
 
     dispatch(setLevelUpAbilities(abilities));
 
-    dispatch(pause(true, { abilityDialog: true, fromLevelUp, playerOpenedAbilityDialog: !fromLevelUp }));
+    dispatch(pause(true, { abilityDialog: true, playerOpenedAbilityDialog: openedByPlayer }));
 };
 
 export default abilityScoreDialog;

--- a/src/components/dialog-manager/actions/confirm-ability-score-dialog.ts
+++ b/src/components/dialog-manager/actions/confirm-ability-score-dialog.ts
@@ -7,9 +7,7 @@ const confirmAbilityScoreDialog = (): RootThunk => async (dispatch, getState): P
 
     dispatch(setAbilityScores(abilities, abilities.points));
 
-    if (getState().dialog.reason.fromLevelUp) {
-        dispatch(pause(false, { fromLevelUp: false }));
-    } else if (getState().dialog.reason.playerOpenedAbilityDialog) {
+    if (getState().dialog.reason.playerOpenedAbilityDialog) {
         dispatch(pause(false, { playerOpenedAbilityDialog: false }));
     } else {
         dispatch(pause(true, { gameInstructions: true }));

--- a/src/components/dialog-manager/dialogs/ability-dialog/index.tsx
+++ b/src/components/dialog-manager/dialogs/ability-dialog/index.tsx
@@ -47,101 +47,11 @@ const AbilityDialog: FunctionComponent<AbilityDialogProps> = (props: AbilityDial
         charisma: minCharisma,
     } = props.dialog.abilitiesMinimum;
 
-    if (props.dialog.reason.playerOpenedAbilityDialog || props.dialog.reason.fromLevelUp) {
-        return (
-            <MicroDialog
-                fullsize
-                keys={["Escape", "Esc", "U"]}
-                onKeyPress={props.confirmAbilityScoreDialog}
-                onClose={() => {
-                    if (props.system.abilityScoreIndicator) {
-                        props.openedAbilityDialog();
-                    }
-
-                    props.closeDialog();
-                }}
-            >
-                <span className="ability-score-title" style={{ marginLeft: "-15px" }}>
-                    Modify your Abilities
-                </span>
-                <div className="flex-column ability-score-dialog-container">
-                    <AbilityScore
-                        name="Strength"
-                        value={strength}
-                        minValue={minStrength}
-                        increment={(): void => props.increment("strength")}
-                        decrement={(): void => props.decrement("strength")}
-                        points={points}
-                        tooltip={"Hit better up close!"}
-                    />
-                    <AbilityScore
-                        name="Constitution"
-                        value={constitution}
-                        minValue={minConstitution}
-                        increment={(): void => props.increment("constitution")}
-                        decrement={(): void => props.decrement("constitution")}
-                        points={points}
-                        tooltip={"Gain more health!"}
-                    />
-                    <AbilityScore
-                        name="Dexterity"
-                        value={dexterity}
-                        minValue={minDexterity}
-                        increment={(): void => props.increment("dexterity")}
-                        decrement={(): void => props.decrement("dexterity")}
-                        points={points}
-                        tooltip={"Defend yourself better! Hit better at range!"}
-                    />
-                    <AbilityScore
-                        name="Charisma"
-                        value={charisma}
-                        minValue={minCharisma}
-                        increment={(): void => props.increment("charisma")}
-                        decrement={(): void => props.decrement("charisma")}
-                        points={points}
-                        tooltip={"Get better prices!"}
-                    />
-                    <AbilityScore
-                        name="Intelligence"
-                        value={intelligence}
-                        minValue={minIntelligence}
-                        increment={(): void => props.increment("intelligence")}
-                        decrement={(): void => props.decrement("intelligence")}
-                        points={points}
-                        tooltip={"Gain more mana! Hit better with magic!"}
-                    />
-                    <AbilityScore
-                        name="Wisdom"
-                        value={wisdom}
-                        minValue={minWisdom}
-                        increment={(): void => props.increment("wisdom")}
-                        decrement={(): void => props.decrement("wisdom")}
-                        points={points}
-                        tooltip={"Restore more with potions!"}
-                    />
-                    <span className="ability-score-dialog-text">
-                        Ability Points remaining:
-                        <span className="ability-score-dialog-points">{points}</span>
-                    </span>
-                    <Button title="Confirm" onClick={props.confirmAbilityScoreDialog} small={true} label="Confirm" />
-                </div>
-            </MicroDialog>
-        );
-    }
-
-    return (
-        <Dialog
-            keys={["Enter", "Esc", "Escape", "U", "u"]}
-            onKeyPress={(key): void => {
-                if (key === "Enter") {
-                    props.confirmAbilityScoreDialog();
-                } else if (key === "Escape" || key === "Esc") {
-                    props.backToCharacterCreation();
-                }
-            }}
-            goBack={props.backToCharacterCreation}
-        >
-            <span className="ability-score-title">Modify your Abilities</span>
+    const abilityScores = (
+        <>
+            <span className="ability-score-title" style={{ marginLeft: "-15px" }}>
+                Modify your Abilities
+            </span>
             <div className="flex-column ability-score-dialog-container">
                 <AbilityScore
                     name="Strength"
@@ -164,7 +74,7 @@ const AbilityDialog: FunctionComponent<AbilityDialogProps> = (props: AbilityDial
                 <AbilityScore
                     name="Dexterity"
                     value={dexterity}
-                    minValue={minStrength}
+                    minValue={minDexterity}
                     increment={(): void => props.increment("dexterity")}
                     decrement={(): void => props.decrement("dexterity")}
                     points={points}
@@ -201,8 +111,43 @@ const AbilityDialog: FunctionComponent<AbilityDialogProps> = (props: AbilityDial
                     Ability Points remaining:
                     <span className="ability-score-dialog-points">{points}</span>
                 </span>
-                <Button title="Confirm" onClick={props.confirmAbilityScoreDialog} small={true} />
+                <Button title="Confirm" onClick={props.confirmAbilityScoreDialog} small={true} label="Confirm" />
             </div>
+        </>
+    );
+
+    if (props.dialog.reason.playerOpenedAbilityDialog) {
+        return (
+            <MicroDialog
+                fullsize
+                keys={["Escape", "Esc", "U", "u"]}
+                onKeyPress={props.confirmAbilityScoreDialog}
+                onClose={() => {
+                    if (props.system.abilityScoreIndicator) {
+                        props.openedAbilityDialog();
+                    }
+
+                    props.closeDialog();
+                }}
+            >
+                {abilityScores}
+            </MicroDialog>
+        );
+    }
+
+    return (
+        <Dialog
+            keys={["Enter", "Esc", "Escape", "U", "u"]}
+            onKeyPress={(key): void => {
+                if (key === "Enter") {
+                    props.confirmAbilityScoreDialog();
+                } else if (key === "Escape" || key === "Esc") {
+                    props.backToCharacterCreation();
+                }
+            }}
+            goBack={props.backToCharacterCreation}
+        >
+            {abilityScores}
         </Dialog>
     );
 };

--- a/src/components/on-screen-buttons/ability-button/index.tsx
+++ b/src/components/on-screen-buttons/ability-button/index.tsx
@@ -38,7 +38,7 @@ const AbilityButton: FunctionComponent<AbilityButtonProps> = (props: AbilityButt
 const mapStateToProps = (state: RootState): StateProps => ({ system: state.system });
 
 const mapDispatchToProps = (dispatch: RootDispatch): DispatchProps => ({
-    abilityScoreDialog: (): void => dispatch(abilityScoreDialog(false)),
+    abilityScoreDialog: (): void => dispatch(abilityScoreDialog(true)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(AbilityButton);

--- a/src/store/dialog/reducer.ts
+++ b/src/store/dialog/reducer.ts
@@ -33,7 +33,6 @@ const initialState: DialogState = {
         journalDialog: false,
         spellbookDialog: false,
         levelUp: false,
-        fromLevelUp: false,
         abilityDialog: false,
         playerOpenedAbilityDialog: false,
         characterCreation: false,

--- a/src/store/journal/types.ts
+++ b/src/store/journal/types.ts
@@ -42,7 +42,7 @@ export interface CriticalHitAction {
 }
 
 export const LEVEL_UP = "LEVEL_UP";
-interface LevelUpAction {
+export interface LevelUpAction {
     type: typeof LEVEL_UP;
     level: number;
     health: number;

--- a/src/store/stats/reducer.ts
+++ b/src/store/stats/reducer.ts
@@ -13,15 +13,18 @@ import {
     UNEQUIP_ITEM,
     DAMAGE_TO_PLAYER,
 } from "./types";
+import { LEVEL_UP } from "../journal/types";
 import { RESET, LOAD } from "../system/types";
 import { USE_PROJECTILE } from "../player/types";
+import { CREATE_CHARACTER } from "../dialog/types";
 
 import { Spell } from "../../types";
 
-import { calculateMaxHealthPool, calculateMaxManaPool } from "../../utils/calculate-max-pool";
 import calculateModifier from "../../utils/calculate-modifier";
 import { calculateDefenceBonus } from "../../utils/calculate-defence-bonus";
-import { CREATE_CHARACTER } from "../dialog/types";
+import { calculateMaxHealthPool, calculateMaxManaPool } from "../../utils/calculate-max-pool";
+import { isAbilityAllocationLevel } from "../../utils/is-ability-allocation-level";
+import { LEVEL_UP_ABILITY_POINTS } from "../../constants";
 
 const initialState: StatsState = {
     abilities: {
@@ -86,6 +89,17 @@ const StatsReducer = (state = initialState, action: StatsActionType): StatsState
             state.defence = state.defence - prevDefenceBonus + currDefenceBonus;
 
             return { ...state, abilities: { ...action.abilities, points: action.points } };
+        }
+
+        case LEVEL_UP: {
+            return {
+                ...state,
+                abilities: {
+                    ...state.abilities,
+                    points:
+                        state.abilities.points + (isAbilityAllocationLevel(action.level) ? LEVEL_UP_ABILITY_POINTS : 0),
+                },
+            };
         }
 
         case CREATE_CHARACTER:

--- a/src/store/stats/types.ts
+++ b/src/store/stats/types.ts
@@ -2,6 +2,7 @@ import { ResetAction, LoadAction } from "../system/types";
 import { Abilities, Character, ItemType, Armour, Weapon } from "../../types";
 import { UseProjectileAction } from "../player/types";
 import { CreateCharacterAction } from "../dialog/types";
+import { LevelUpAction } from "../journal/types";
 
 export interface StatsState {
     abilities: Abilities & {
@@ -103,4 +104,5 @@ export type StatsActionType =
     | UseProjectileAction
     | CreateCharacterAction
     | LoadAction
+    | LevelUpAction
     | ResetAction;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,7 +94,6 @@ export interface PauseReason {
     tutorialDialog?: boolean;
     tutorialPage?: string;
     levelUp?: boolean;
-    fromLevelUp?: boolean;
     abilityDialog?: boolean;
     playerOpenedAbilityDialog?: boolean;
     characterCreation?: boolean;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The Ability Indicator now properly disappears when the ability dialog is closed, no matter if there are unallocated points.
It is also now possible to close the dialog with 'u'

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #12 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
