### PR TITLE
Remove Indicator on Confirm

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,8 +113,6 @@ const App: FunctionComponent<AppProps> = (props: AppProps) => {
     const disableJournal =
         gameStart || gameOver || !gameRunning || !journalSideMenu || !props.dialog.journalSideMenuOpen;
 
-    console.log(gameStart, gameOver, !gameRunning, !journalLittleSideMenu, !props.dialog.journalSideMenuOpen);
-
     return (
         <div className="centered flex-row">
             <div

--- a/src/components/dialog-manager/dialogs/ability-dialog/index.tsx
+++ b/src/components/dialog-manager/dialogs/ability-dialog/index.tsx
@@ -116,19 +116,17 @@ const AbilityDialog: FunctionComponent<AbilityDialogProps> = (props: AbilityDial
         </>
     );
 
+    if (props.system.abilityScoreIndicator) {
+        props.openedAbilityDialog();
+    }
+
     if (props.dialog.reason.playerOpenedAbilityDialog) {
         return (
             <MicroDialog
                 fullsize
                 keys={["Escape", "Esc", "U", "u"]}
                 onKeyPress={props.confirmAbilityScoreDialog}
-                onClose={() => {
-                    if (props.system.abilityScoreIndicator) {
-                        props.openedAbilityDialog();
-                    }
-
-                    props.closeDialog();
-                }}
+                onClose={props.closeDialog}
             >
                 {abilityScores}
             </MicroDialog>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
If the player pressed 'Confirm' in the Ability Dialog, the indicator would still appear.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#12 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
